### PR TITLE
Gets metadata from fq name, fixes and splits multqic in two, adds bio-type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,18 @@
 
 PR centric changelog with description of notable changes implemented in a PR.
 
+v0.2 - 29/02/2021 - MultiQC changes, metadata from file name
+  Added:
+    - Metadata retrieval from fq file names in the input channel (bio-type, seq-type, seq-machine, flowcell-ID, lane, barcode). This is optional and can be switched off by using --metadata_from_file_name false *true by default)
+    - Check for correct metadata naming format for fq file (if --metadata_from_file_name is true, as it is by default)
+    - Check for matching smaple_id specified in csv file and in fq file name (can be turned off by --double_check_sample_id false, true buy default)
+    - Process multiqc_prealignment_report_by_sample to create smaller realignment multiqc reports for each batch of files that corresponds to same sample_id.
+  Fixed:
+    - Multiqc not showing fastqc report for trimmed reads (reason - "_trimmed" substrings are automatically removed from file names by multiqc before plotting, so the trimmed pair overwrote the untrimmed pair and showed up as untrimmed pair in the report)
+  Changes:
+    - Required input name format now needs to have also the "bio-type" field, so the example data for test2 has been changed on s3 bucket (old files retained for old tests)
+
+
 
 v0.1 - 29/02/2021 - Adds first pipeline template and 4 steps
   Added:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,84 @@
 
 Nextflow pipeline for germline variant calling.
 
-Test examples:
+## Introduction
+
+Nf-germline-snv is a genomics pipeline designed with Nextflow and Docker to use common bioinformatic tools to perform germline variant calling.
+
+Pipeline uses the following tools:
+ - fastqc
+ - flexbar
+ - multiqc
+ - bwa
+ - samtools
+ - bcftools
+ - picard
+ - gatk
+ - manta
+ - strelka
+
+## Quick Start
+1. Install [`Nextflow`](https://nf-co.re/usage/installation) (`>=20.04.0`)
+
+2. Install [`Docker`](https://docs.docker.com/engine/installation/) (Needs root permissions. Don't forget to activate docker service after installation)
+
+3. Install [`Graphviz`](https://graphviz.org/download/) (optional)
+
+4. Download the pipeline and run it with test data with a single command:
+```
+nextflow run . -profile test
+```
+
+5. Using your own data:
+```
+nextflow run . --input test_data_paths.csv --metadata_from_file_name false
+```
+
+## Pipeline Inputs
+
+Pipeline takes as an input raw paired-end fastq[.gz] files, provided as paths via an input csv file:
+
+`input.csv`:
+```
+sample,fastq_1,fastq_2
+sample_S1_L001,path/to/data/sample_S1_L001_R1_001.fastq.gz,path/to/data/sample_S1_L001_R2_001.fastq.gz
+sample_S1_L002,path/to/data/sample_S1_L001_R1_002.fastq.gz,path/to/data/sample_S1_L001_R2_002.fastq.gz
+```
+First line of file must be a header. First CSV column must contain sample names, other two columns must specify paths to forward and reverse fastq files. It is possible to specify s3 paths to AWS s3 buckets. If you wish to specify s3 paths to non-amazon s3 buckets, create and use a config similar to [conf/yandex.config](https://github.com/zenomeplatform/nf-germline-snv/blob/main/conf/yandex.config).
+
+### Naming convention
+By default the pipeline relies on obtaining certain metadata information directly from the fastq file names:
+- sample_ID
+- bio-type
+- seq-type
+- seq-machine
+- flowcell-ID
+- lane
+- barcode
+
+To provide that kind of information fastq file names must follow the naming convention:
+```
+{sampleID}-{bio-type}-{seq-type}-{seq-machine}-{flowcell-ID}-{lane}-{barcode}-{read-direction}.fq[.gz]
+``` 
+Where individual items are separated by single dashes `-` (can be changed with `--sample_name_format_delimeter` parameter)
+
+Example:
+```
+ZD210122-GED-E080AS6-MG-300056277-3-66-F.fq.gz
+```
+
+If you do not want to provide metadata in such way and want to treat all your samples independently, you can use pipeline parameter `--metadata_from_file_name false`
+
+### Bio-type
+Possible values:
+`GED` - germline DNA
+`SOD` - somatic DNA
+`GER` - germline RNA
+`SOR` - somatic RNA
+`CFD` - cell free DNA
+`SCD` - single cell DNA
+
+## Test profiles
 
 Using public test data:
 ```
@@ -13,5 +90,5 @@ Using private test data:
 ```
 nextflow run . -profile test2,yandex --accessKey '<accessKey>' --secretKey '<secretKey>'
 ```
-where `<accessKey>` and `<secretKey>` are credentials to private s3 bucket s3://zenome-ngs-data .
+where `<accessKey>` and `<secretKey>` are credentials to private s3 bucket, for example s3://zenome-ngs-data .
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -18,6 +18,7 @@ params {
 
   // Input data
   input = "$baseDir/testdata/TESTX/TESTX_test_data_paths.csv"
+  metadata_from_file_name = false
 
   // Annotations
   fasta = 'https://github.com/nf-core/test-datasets/raw/hic/reference/W303_SGD_2015_JRIU00000000.fsa'

--- a/conf/test2.config
+++ b/conf/test2.config
@@ -17,7 +17,7 @@ params {
   max_time = 1.h
 
   // Input data
-  input = "s3://zenome-ngs-data/nf-germline-nf/testdata/BRCA_demo_1_single_subset_25k/BRCA_demo_1_single_subset_25k.csv"
+  input = "s3://zenome-ngs-data/nf-germline-nf/testdata/BRCA_demo_1_single_subset_25k/BRCA_demo_1_single_subset_25k_with_biotype.csv"
 
   // Annotations
   fasta = 'https://github.com/nf-core/test-datasets/raw/hic/reference/W303_SGD_2015_JRIU00000000.fsa'

--- a/main.nf
+++ b/main.nf
@@ -304,39 +304,43 @@ ch_fastq_qc_raw
     .into { ch_prealignment_multiqc_files_by_sample; ch_prealignment_multiqc_files_all }
 
 
-process multiqc_prealignment_report_by_sample {
-    tag "$sample_name"
-    label 'low_memory'
-    publishDir "${params.outdir}/multiqc_prealignment_report/${sample_name}/", mode: 'copy'
+if (params.multiqc_prealignment_by_sample) {
+  process multiqc_prealignment_report_by_sample {
+      tag "$sample_name"
+      label 'low_memory'
+      publishDir "${params.outdir}/multiqc_prealignment_report/${sample_name}/", mode: 'copy'
 
-    input:
-    set val(sample_name), file(fastqc_raw_dir), file(trimming_log), file(fastqc_trimmed_dir) from ch_prealignment_multiqc_files_by_sample
+      input:
+      set val(sample_name), file(fastqc_raw_dir), file(trimming_log), file(fastqc_trimmed_dir) from ch_prealignment_multiqc_files_by_sample
 
-    output:
-    file("multiqc_report.html")
+      output:
+      file("multiqc_report.html")
 
-    script:
-    """
-    multiqc .
-    """
-  }
+      script:
+      """
+      multiqc .
+      """
+    }
+}
 
 
-process multiqc_prealignment_report_all {
-    label 'low_memory'
-    publishDir "${params.outdir}/multiqc_prealignment_report/", mode: 'copy'
+if (params.multiqc_prealignment_all) {
+  process multiqc_prealignment_report_all {
+      label 'low_memory'
+      publishDir "${params.outdir}/multiqc_prealignment_report/", mode: 'copy'
 
-    input:
-    file("*") from ch_prealignment_multiqc_files_all.collect()
+      input:
+      file("*") from ch_prealignment_multiqc_files_all.collect()
 
-    output:
-    file("multiqc_report.html")
+      output:
+      file("multiqc_report.html")
 
-    script:
-    """
-    multiqc .
-    """
-  }
+      script:
+      """
+      multiqc .
+      """
+    }
+}
 
 
 

--- a/main.nf
+++ b/main.nf
@@ -320,7 +320,7 @@ process multiqc_prealignment_report_all {
     publishDir "${params.outdir}/multiqc_prealignment_report/", mode: 'copy'
 
     input:
-    set val(sample_name), file(fastqc_raw_dir), file(trimming_log), file(fastqc_trimmed_dir) from ch_prealignment_multiqc_files_all.collect()
+    file("*") from ch_prealignment_multiqc_files_all.collect()
 
     output:
     file("multiqc_report.html")

--- a/main.nf
+++ b/main.nf
@@ -229,8 +229,8 @@ process trim_fastqc {
 
     output:
     set val(sample_name),
-        file("${fastq_1.simpleName}_trimmed.fastq.gz"),
-        file("${fastq_2.simpleName}_trimmed.fastq.gz"),
+        file("${fastq_1.simpleName}_trim.fastq.gz"),
+        file("${fastq_2.simpleName}_trim.fastq.gz"),
         val(seq_type),
         val(seq_machine),
         val(flowcell_id),
@@ -251,8 +251,8 @@ process trim_fastqc {
         --zip-output GZ \
         --reads ${fastq_1} \
         --reads2 ${fastq_2} \
-        --output-reads ${fastq_1.simpleName}_trimmed.fastq \
-        --output-reads2 ${fastq_2.simpleName}_trimmed.fastq \
+        --output-reads ${fastq_1.simpleName}_trim.fastq \
+        --output-reads2 ${fastq_2.simpleName}_trim.fastq \
         --output-log flexbar_${sample_name}.log \
         $adapters_param
 

--- a/main.nf
+++ b/main.nf
@@ -292,16 +292,35 @@ process fastqc_trimmed {
   }
 
 
-ch_prealignment_multiqc_files = ch_fastq_qc_raw
-                    .join(ch_trimming_report, by: 0)
-                    .join(ch_fastq_qc_trimmed, by: 0)
+ch_fastq_qc_raw
+    .join(ch_trimming_report, by: 0)
+    .join(ch_fastq_qc_trimmed, by: 0)
+    .into { ch_prealignment_multiqc_files_by_sample; ch_prealignment_multiqc_files_all }
 
-process multiqc_prealignment_report {
+
+process multiqc_prealignment_report_by_sample {
+    label 'low_memory'
+    publishDir "${params.outdir}/multiqc_prealignment_report/${sample_name}/", mode: 'copy'
+
+    input:
+    set val(sample_name), file(fastqc_raw_dir), file(trimming_log), file(fastqc_trimmed_dir) from ch_prealignment_multiqc_files_by_sample
+
+    output:
+    file("multiqc_report.html")
+
+    script:
+    """
+    multiqc .
+    """
+  }
+
+
+process multiqc_prealignment_report_all {
     label 'low_memory'
     publishDir "${params.outdir}/multiqc_prealignment_report/", mode: 'copy'
 
     input:
-    set val(sample_name), file(fastqc_raw_dir), file(trimming_log), file(fastqc_trimmed_dir) from ch_prealignment_multiqc_files.collect()
+    set val(sample_name), file(fastqc_raw_dir), file(trimming_log), file(fastqc_trimmed_dir) from ch_prealignment_multiqc_files_all.collect()
 
     output:
     file("multiqc_report.html")

--- a/main.nf
+++ b/main.nf
@@ -136,7 +136,7 @@ Channel
           sample_name_parsed = file(fastq_path_1).simpleName.split(params.sample_name_format_delimeter)
 
           if (sample_name_parsed.length != params.sample_name_expected_item_number) {
-            exit 1, "Error when parsing fastq file name. Each file name must have the following format: \n${params.sample_name_format}. \nExample         : ${params.sample_name_format_example} \nFailed file name: ${file(fastq_path_1).getName()} \n\nPlease follow the fastq file naming format, because pipeline extracts sample metadata (seq-type, seq-machine, flowcell-ID, lane, and barcode) from the file name. \nYou can disable infering metadata from file name with parameter: \n--metadata_from_file_name false \nIn this case seq-type and seq-machine will be left blank, and all samples will be processed as completely indepentdent samples."
+            exit 1, "Error when parsing fastq file name. Each file name must have the following format: \n${params.sample_name_format}. \nExample         : ${params.sample_name_format_example} \nFailed file name: ${file(fastq_path_1).getName()} \n\nPlease follow the fastq file naming format, because pipeline extracts sample metadata (bio-type, seq-type, seq-machine, flowcell-ID, lane, and barcode) from the file name. \nYou can disable infering metadata from file name with parameter: \n--metadata_from_file_name false \nIn this case bio-type, seq-type and seq-machine will be left blank, and all samples will be processed as completely indepentdent samples."
           }
 
           if (params.double_check_sample_id) {
@@ -146,14 +146,16 @@ Channel
             }
           }
 
-          seq_type    = sample_name_parsed[1]
-          seq_machine = sample_name_parsed[2]
-          flowcell_id = sample_name_parsed[3]
-          lane        = sample_name_parsed[4]
-          barcode     = sample_name_parsed[5]
+          bio_type    = sample_name_parsed[1]
+          seq_type    = sample_name_parsed[2]
+          seq_machine = sample_name_parsed[3]
+          flowcell_id = sample_name_parsed[4]
+          lane        = sample_name_parsed[5]
+          barcode     = sample_name_parsed[6]
       }
 
       if (!params.metadata_from_file_name) {
+          bio_type    = "not_provided"
           seq_type    = "not_provided"
           seq_machine = "not_provided"
           flowcell_id = sample_name
@@ -161,7 +163,7 @@ Channel
           barcode     = sample_name
       }
 
-      [ sample_name, file(fastq_path_1), file(fastq_path_2), seq_type, seq_machine, flowcell_id, lane, barcode ]
+      [ sample_name, file(fastq_path_1), file(fastq_path_2), bio_type, seq_type, seq_machine, flowcell_id, lane, barcode ]
     }
     .set { ch_input_fastq }
 
@@ -188,6 +190,7 @@ process fastqc_raw {
     set val(sample_name),
         file(fastq_1),
         file(fastq_2),
+        val(bio_type),
         val(seq_type),
         val(seq_machine),
         val(flowcell_id),
@@ -220,6 +223,7 @@ process trim_fastqc {
     set val(sample_name),
         file(fastq_1),
         file(fastq_2),
+        val(bio_type),
         val(seq_type),
         val(seq_machine),
         val(flowcell_id),
@@ -231,6 +235,7 @@ process trim_fastqc {
     set val(sample_name),
         file("${fastq_1.simpleName}_trim.fastq.gz"),
         file("${fastq_2.simpleName}_trim.fastq.gz"),
+        val(bio_type),
         val(seq_type),
         val(seq_machine),
         val(flowcell_id),
@@ -270,6 +275,7 @@ process fastqc_trimmed {
     set val(sample_name),
         file(fastq_1),
         file(fastq_2),
+        val(bio_type),
         val(seq_type),
         val(seq_machine),
         val(flowcell_id),

--- a/main.nf
+++ b/main.nf
@@ -299,6 +299,7 @@ ch_fastq_qc_raw
 
 
 process multiqc_prealignment_report_by_sample {
+    tag "$sample_name"
     label 'low_memory'
     publishDir "${params.outdir}/multiqc_prealignment_report/${sample_name}/", mode: 'copy'
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,6 +16,8 @@ params {
     metadata_from_file_name = true
     double_check_sample_id = true
 
+    multiqc_prealignment_by_sample = true
+    multiqc_prealignment_all = true
 
     // when set to true, prints help and exits
     help = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -57,7 +57,7 @@ params {
 
     // trim_fastqc
     adapters = null
-    adapter_min_overlap = 7
+    adapter_min_overlap = 8
     adapter_trim_end = "RIGHT"
     pre_trim_left = 13
     max_uncalled = 300
@@ -65,10 +65,10 @@ params {
     zip_output = "GZ"
 
     // Pipeline internal parameters
-    sample_name_format = "{sampleID}-{seq-type}-{seq-machine}-{flowcell-ID}-{lane}-{barcode}-{read-direction}.fq[.gz]"
+    sample_name_format = "{sampleID}-{bio-type}-{seq-type}-{seq-machine}-{flowcell-ID}-{lane}-{barcode}-{read-direction}.fq[.gz]"
     sample_name_format_delimeter = '-'
-    sample_name_expected_item_number = 7
-    sample_name_format_example = "ZD210122-E080AS6-MG-300056277-3-66-F.fq.gz"
+    sample_name_expected_item_number = 8
+    sample_name_format_example = "ZD210122-GED-E080AS6-MG-300056277-3-66-F.fq.gz"
 }
 
 cleanup = params.cleanup

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,6 +13,9 @@ params {
     outdir = 'results'
     tracedir = "${params.outdir}/pipeline_info"
 
+    metadata_from_file_name = true
+    double_check_sample_id = true
+
 
     // when set to true, prints help and exits
     help = false
@@ -60,6 +63,12 @@ params {
     max_uncalled = 300
     min_read_length = 25
     zip_output = "GZ"
+
+    // Pipeline internal parameters
+    sample_name_format = "{sampleID}-{seq-type}-{seq-machine}-{flowcell-ID}-{lane}-{barcode}-{read-direction}.fq[.gz]"
+    sample_name_format_delimeter = '-'
+    sample_name_expected_item_number = 7
+    sample_name_format_example = "ZD210122-E080AS6-MG-300056277-3-66-F.fq.gz"
 }
 
 cleanup = params.cleanup


### PR DESCRIPTION
## This PR:
### Adds:
- [Metadata retrieval](https://github.com/zenomeplatform/nf-germline-snv/blob/0b939ec43f930dc3679c0bd61c111fd3f04c6af8/main.nf#L149-L154) from fq file names in the input channel (bio-type, seq-type, seq-machine, flowcell-ID, lane, barcode). This is optional and can be switched off by using `--metadata_from_file_name false` *true by default)
- [Check for correct metadata naming](https://github.com/zenomeplatform/nf-germline-snv/blob/0b939ec43f930dc3679c0bd61c111fd3f04c6af8/main.nf#L136-L140) format for fq file (if `--metadata_from_file_name` is `true`, as it is by default)
- [Check for matching smaple_id](https://github.com/zenomeplatform/nf-germline-snv/blob/0b939ec43f930dc3679c0bd61c111fd3f04c6af8/main.nf#L142-L147) specified in csv file and in fq file name (can be turned off by `--double_check_sample_id false`, true buy default)
- [Process `multiqc_prealignment_report_by_sample`](https://github.com/zenomeplatform/nf-germline-snv/blob/0b939ec43f930dc3679c0bd61c111fd3f04c6af8/main.nf#L301-L322) to create smaller realignment multiqc reports for each batch of files that corresponds to same sample_id.
### Fixes:
 - multiqc not showing fastqc report for trimmed reads (reason - "_trimmed" substrings are automatically removed from file names by multiqc before plotting, so the trimmed pair overwrote the untrimmed pair and showed up as untrimmed pair in the report)

### Changes:
 - required input name format now needs to have also the "bio-type" field, so the example data for test2 has been changed on s3 bucket (old files retained for old tests)
 
 ## To test
To test the pipeline run the same two test commands as before and check the `results/multiqc_prealignment_report` folder for the report. New subfolders named after sample names now contain additional per-sample multiqc reports

Clone the repository and checkout to current PR branch:
```
git clone https://github.com/zenomeplatform/nf-germline-snv
cd nf-germline-snv
git checkout vlad-dev-1
```
Run test using public test data:
```
nextflow run . -profile test
```

Run test using private test data located on private yandex s3 bucket:
```
nextflow run . -profile test2,yandex --accessKey '<accessKey>' --secretKey '<secretKey>'
```
where `<accessKey>` and `<secretKey>` are credentials to private s3 bucket s3://zenome-ngs-data .